### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/_locales/es/LC_MESSAGES/tutorial.po
+++ b/docs/_locales/es/LC_MESSAGES/tutorial.po
@@ -400,7 +400,7 @@ msgstr "Depuración"
 #: ../tutorial.rst:233
 msgid ""
 "As we are writing code, we might (we will) make mistakes. In this case, ,"
-" it is always helpul to read the error messages returned by the system."
+" it is always helpful to read the error messages returned by the system."
 msgstr ""
 "Como estamos escribiendo código, nosotros podríamos (vamos a) cometer "
 "errores. En este caso, siempre es útil leer los mensajes de error "

--- a/docs/_locales/tutorial.pot
+++ b/docs/_locales/tutorial.pot
@@ -257,7 +257,7 @@ msgid "Debugging"
 msgstr ""
 
 #: ../tutorial.rst:233
-msgid "As we are writing code, we might (we will) make mistakes. In this case, , it is always helpul to read the error messages returned by the system."
+msgid "As we are writing code, we might (we will) make mistakes. In this case, , it is always helpful to read the error messages returned by the system."
 msgstr ""
 
 #: ../tutorial.rst:236

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -231,7 +231,7 @@ Debugging
 ---------
 
 As we are writing code, we might (we will) make mistakes. In this case, , it is
-always helpul to read the error messages returned by the system.
+always helpful to read the error messages returned by the system.
 
 It is also very helpful to be able to log messages from our code, so we
 understand what is going on exactly when it is executed.


### PR DESCRIPTION
Reading https://rapidoplone.readthedocs.io/en/latest/ I came across some typos.